### PR TITLE
Fix docstring for body content absence

### DIFF
--- a/food_co2_estimator/url/url2markdown.py
+++ b/food_co2_estimator/url/url2markdown.py
@@ -81,8 +81,8 @@ def convert_body_to_markdown(soup: BeautifulSoup) -> str | None:
 def get_markdown_from_url(url: str) -> str | None:
     """
     Given a URL, fetch its HTML, remove unwanted elements,
-    and return the content of <body> as Markdown. Returns an
-    empty string if there is no <body> content.
+    and return the content of <body> as Markdown. Returns
+    ``None`` if there is no <body> content.
     """
     # 1. Fetch the page content
     html_text = fetch_page_content(url, HEADERS)


### PR DESCRIPTION
## Summary
- clarify `get_markdown_from_url` documentation

## Testing
- `poetry run pytest` *(fails: `/root/.pyenv/shims/python` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3f3d78d4832d95969cfc793fab2c