### PR TITLE
Fix inconsistent variable naming

### DIFF
--- a/food_co2_estimator/chains/rag_co2_estimator.py
+++ b/food_co2_estimator/chains/rag_co2_estimator.py
@@ -33,20 +33,20 @@ def rag_co2_emission_chain(verbose: bool) -> RunnableSerializable:
 
 
 def should_include_ingredient(
-    item: EnrichedIngredient, negligeble_threshold: float
+    item: EnrichedIngredient, negligible_threshold: float
 ) -> bool:
-    return above_weight_threshold(item, negligeble_threshold) and ingredient_to_ignore(
+    return above_weight_threshold(item, negligible_threshold) and ingredient_to_ignore(
         item
     )
 
 
 def above_weight_threshold(
-    item: EnrichedIngredient, negligeble_threshold: float
+    item: EnrichedIngredient, negligible_threshold: float
 ) -> bool:
     return (
         item.weight_estimate is not None
         and item.weight_estimate.weight_in_kg is not None
-        and negligeble_threshold < item.weight_estimate.weight_in_kg
+        and negligible_threshold < item.weight_estimate.weight_in_kg
     )
 
 
@@ -62,7 +62,7 @@ def ingredient_to_ignore(item: EnrichedIngredient) -> bool:
 @log_with_url
 async def get_co2_emissions(
     verbose: bool,
-    negligeble_threshold: float,
+    negligible_threshold: float,
     recipe: EnrichedRecipe,
 ) -> CO2Emissions:
     emission_chain = rag_co2_emission_chain(verbose)
@@ -70,7 +70,7 @@ async def get_co2_emissions(
     ingredients_input = [
         item.en_name
         for item in recipe.ingredients
-        if should_include_ingredient(item, negligeble_threshold)
+        if should_include_ingredient(item, negligible_threshold)
     ]
 
     parsed_rag_emissions: CO2Emissions = await emission_chain.ainvoke(ingredients_input)

--- a/food_co2_estimator/pydantic_models/estimator.py
+++ b/food_co2_estimator/pydantic_models/estimator.py
@@ -24,7 +24,7 @@ def env_store_in_cache():
 class RunParams(pydantic.BaseModel):
     url: str
     uid: str = pydantic.Field(default_factory=get_uuid)
-    negligeble_threshold: float = NEGLIGIBLE_THRESHOLD
+    negligible_threshold: float = NEGLIGIBLE_THRESHOLD
     use_cache: bool = pydantic.Field(default_factory=env_use_cache)
     store_in_cache: bool = pydantic.Field(default_factory=env_store_in_cache)
 
@@ -33,7 +33,7 @@ class RunParams(pydantic.BaseModel):
             return False
         if self.url != value.url:
             return False
-        if self.negligeble_threshold != value.negligeble_threshold:
+        if self.negligible_threshold != value.negligible_threshold:
             return False
         return True
 

--- a/food_co2_estimator/utils/output_generator.py
+++ b/food_co2_estimator/utils/output_generator.py
@@ -15,7 +15,7 @@ MAX_DINNER_EMISSION_PER_CAPITA = 2.2
 
 def generate_output_model(
     enriched_recipe: EnrichedRecipe,
-    negligeble_threshold: float,
+    negligible_threshold: float,
     number_of_persons: int | None,
 ) -> RecipeCO2Output:
     total_co2 = 0.0
@@ -48,12 +48,12 @@ def generate_output_model(
             continue
 
         # If the weight is negligible, mark it as such and set CO2 to 0.
-        if not should_include_ingredient(ingredient, negligeble_threshold):
+        if not should_include_ingredient(ingredient, negligible_threshold):
             weight_estimation_notes = weight_estimate.weight_calculation
             wt = round(weight_estimate.weight_in_kg, 3)
             calculation_notes = (
                 f"Weight on {wt} kg is negligible"
-                if not above_weight_threshold(ingredient, negligeble_threshold)
+                if not above_weight_threshold(ingredient, negligible_threshold)
                 else "Ingredient is ignored in calculation"
             )
             ingredients_list.append(

--- a/tests/scripts/create_output_data.py
+++ b/tests/scripts/create_output_data.py
@@ -39,7 +39,7 @@ def process_and_store_enriched_recipe(file_name: str, url: str):
 
     output_model = generate_output_model(
         enriched_recipe=enriched_recipe,
-        negligeble_threshold=NEGLIGIBLE_THRESHOLD,
+        negligible_threshold=NEGLIGIBLE_THRESHOLD,
         number_of_persons=enriched_recipe.persons,
     )
     # Store the final enriched recipe with translations as JSON

--- a/tests/scripts/create_rag_co2_estimates.py
+++ b/tests/scripts/create_rag_co2_estimates.py
@@ -21,7 +21,7 @@ async def save_rag_co2_estimates(file_name: str, url: str) -> CO2Emissions:
     weight_estimates = get_expected_weight_estimates(file_name)
     enriched_recipe.update_with_weight_estimates(weight_estimates)
     rag_co2_estimates = await get_co2_emissions(
-        verbose=False, recipe=enriched_recipe, negligeble_threshold=NEGLIGIBLE_THRESHOLD
+        verbose=False, recipe=enriched_recipe, negligible_threshold=NEGLIGIBLE_THRESHOLD
     )
 
     enriched_recipe.update_with_co2_per_kg_db(rag_co2_estimates)

--- a/tests/test_blob_caching.py
+++ b/tests/test_blob_caching.py
@@ -163,10 +163,10 @@ def test_url_to_key(url, expected):
 
 @pytest.mark.asyncio
 async def test_cache_results(monkeypatch: pytest.MonkeyPatch):
-    async def mock_func(runparams):
+    async def mock_func(run_params):
         return True, "result"
 
-    runparams = RunParams(
+    run_params = RunParams(
         url="https://www.example.com", use_cache=True, store_in_cache=True
     )
     mock_cache_results = cache_results(mock_func)
@@ -177,13 +177,13 @@ async def test_cache_results(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         "food_co2_estimator.blob_caching.cache_estimator_result", lambda x, y: None
     )
-    success, result = await mock_cache_results(runparams=runparams)
+    success, result = await mock_cache_results(run_params=run_params)
     assert success
     assert result == "result"
 
 
 def test_cache_estimator_result(monkeypatch: pytest.MonkeyPatch):
-    runparams = RunParams(
+    run_params = RunParams(
         url="https://www.example.com", use_cache=True, store_in_cache=True
     )
     result = '{"key": "value"}'
@@ -192,16 +192,16 @@ def test_cache_estimator_result(monkeypatch: pytest.MonkeyPatch):
         "food_co2_estimator.blob_caching.store_json_in_blob_storage"
     )
     with mock_store_json_in_blob_storage as mock_store:
-        cache_estimator_result(runparams, result)
+        cache_estimator_result(run_params, result)
         mock_store.assert_called_once()
 
 
 def test_fetch_matching_cache(monkeypatch: pytest.MonkeyPatch):
-    runparams = RunParams(
+    run_params = RunParams(
         url="https://www.example.com", use_cache=True, store_in_cache=True
     )
     cache_data = {
-        "runparams": runparams.model_dump(),
+        "runparams": run_params.model_dump(),
         "result": {"key": "value"},
         "timestamp": get_now_isoformat(),
     }
@@ -210,5 +210,5 @@ def test_fetch_matching_cache(monkeypatch: pytest.MonkeyPatch):
         "food_co2_estimator.blob_caching.get_cache", lambda x: cache_data
     )
 
-    result = fetch_matching_cache(runparams)
+    result = fetch_matching_cache(run_params)
     assert result == (True, json.dumps({"key": "value"}))

--- a/tests/test_chains/test_rag_co2_estimator.py
+++ b/tests/test_chains/test_rag_co2_estimator.py
@@ -30,7 +30,7 @@ async def test_rag_co2_estimator_chain(
     rag_co2_emissions = await get_co2_emissions(
         verbose=False,
         recipe=enriched_recipe,
-        negligeble_threshold=NEGLIGIBLE_THRESHOLD,
+        negligible_threshold=NEGLIGIBLE_THRESHOLD,
     )
     enriched_recipe.update_with_co2_per_kg_db(rag_co2_emissions)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,7 +53,7 @@ async def test_async_estimator(
 
     # Call the function
     success, output = await async_estimator(
-        runparams=RunParams(url="dummy_url", use_cache=False, store_in_cache=False),
+        run_params=RunParams(url="dummy_url", use_cache=False, store_in_cache=False),
     )
     if success is False:
         raise RuntimeError(f"Failed to run async_estimator: {output}")

--- a/tests/test_utils/test_output_generator.py
+++ b/tests/test_utils/test_output_generator.py
@@ -118,7 +118,7 @@ def enriched_recipe_search_english():
 
 
 @pytest.mark.parametrize(
-    "enriched_recipe, negligeble_threshold, expected_output",
+    "enriched_recipe, negligible_threshold, expected_output",
     [
         (
             "enriched_recipe_db_english",
@@ -282,13 +282,13 @@ def enriched_recipe_search_english():
 def test_generate_output(
     request: pytest.FixtureRequest,
     enriched_recipe: str,
-    negligeble_threshold: float,
+    negligible_threshold: float,
     expected_output: RecipeCO2Output,
 ) -> None:
     recipe = request.getfixturevalue(enriched_recipe)
     result = generate_output_model(
         enriched_recipe=recipe,
-        negligeble_threshold=negligeble_threshold,
+        negligible_threshold=negligible_threshold,
         number_of_persons=4,
     )
     assert result.model_dump() == expected_output.model_dump()


### PR DESCRIPTION
## Summary
- rename `negligeble_threshold` to `negligible_threshold`
- rename parameter variables for better clarity
- update tests accordingly

## Testing
- `pytest -q` *(fails: pyenv missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f58cb0db4832dbd6386f797f8ade7