### PR TITLE
Add Danish prompt examples and clarify output language

### DIFF
--- a/food_co2_estimator/prompt_templates/recipe_extractor.py
+++ b/food_co2_estimator/prompt_templates/recipe_extractor.py
@@ -120,6 +120,8 @@ God fornøjelse med strikketøjet!
 SYSTEM_PROMPT = """
 You are an expert in extracting food recipe data from unstructured text in Danish or English. Your task is to identify and extract:
 
+Return the extracted information in the same language as the input. If the recipe text is in Danish, respond in Danish. If it is in English, respond in English.
+
 1. Title of the recipe
 2. Ingredients (with amounts in numeric format and standardized units)
 3. Number of persons (servings)

--- a/food_co2_estimator/prompt_templates/weight_estimator.py
+++ b/food_co2_estimator/prompt_templates/weight_estimator.py
@@ -38,6 +38,33 @@ Examples of a bunch/bnch of an ingredient - use them as a guideline:
 The weights of bunches are estimated as the highest possible weight.
 """
 
+# Danish translation of the general weight lookup table
+DA_WEIGHT_RECALCULATIONS = """
+1 dåse = 400 g = 0.4 kg
+1 bouillonterning = 4 g = 0.004 kg
+1 løg = 170 g = 0.170 kg
+1 peberfrugt = 150 g = 0.150 kg
+1 dåse tomatpuré = 140 g = 0.140 kg
+1 spiseske/spsk = 15 g  = 0.015 kg
+1 teskefuld/tsk = 5 g = 0.005 kg
+1 kartoffel = 170 - 300 g = 0.170 - 0.300 kg
+1 gulerod = 100 g = 0.100 kg
+1 citron = 85 g = 0.085 kg
+1 tortilla = 30 g = 0.030 kg
+1 squash = 400 g = 0.400 kg
+1 fed hvidløg = 0.004 kg
+1 dl / deciliter = 0.1 kg
+ris til 1 person / portion = 125 g = 0.125 kg
+Håndfuld krydderurter (basilikum, oregano osv.) = 0.025 kg
+
+Eksempler på et bundt/bdt af en ingrediens - brug dem som rettesnor:
+1 bundt persille = 50 g = 0.050 kg
+1 bundt asparges = 500 g = 0.500 kg
+1 bundt gulerødder = 750 g = 0.750 kg
+1 bundt tomater = 500 g = 0.500 kg
+Vægten af bundter estimeres som den højest mulige vægt.
+"""
+
 EN_INPUT_EXAMPLE = """
 1 can chopped tomatoes
 200 g pasta
@@ -152,6 +179,84 @@ ANSWER_EXAMPLE_OBJ = WeightEstimates(
 
 ANSWER_EXAMPLE = ANSWER_EXAMPLE_OBJ.model_dump_json(indent=2)
 
+# Danish example answer constructed with Danish ingredient names
+DA_ANSWER_EXAMPLE_OBJ = WeightEstimates(
+    weight_estimates=[
+        WeightEstimate(
+            ingredient="1 dåse hakkede tomater",
+            weight_calculation="1 dåse = 400 g, 1 * 400 g = 400 g = 0.4 kg",
+            weight_in_kg=0.4,
+        ),
+        WeightEstimate(
+            ingredient="200 g pasta",
+            weight_calculation="200 g = 200 g = 0.2 kg",
+            weight_in_kg=0.2,
+        ),
+        WeightEstimate(
+            ingredient="500 ml vand",
+            weight_calculation="500 ml = 500 g, 1 * 500 g = 500 g = 0.5 kg",
+            weight_in_kg=0.5,
+        ),
+        WeightEstimate(
+            ingredient="250 g hakket kød",
+            weight_calculation="250 g = 250 g = 0.25 kg",
+            weight_in_kg=0.25,
+        ),
+        WeightEstimate(
+            ingredient="0.5 blomkål",
+            weight_calculation="1 blomkål = 500 g, 0.5 * 500 g = 250 g = 0.25 kg",
+            weight_in_kg=0.25,
+        ),
+        WeightEstimate(
+            ingredient="1 tsk sukker",
+            weight_calculation="1 teskefuld = 5 g, 1 * 5 g = 5 g = 0.005 kg",
+            weight_in_kg=0.005,
+        ),
+        WeightEstimate(
+            ingredient="1 økologisk citron",
+            weight_calculation="1 citron = 85 g, 1 * 85 g = 85 g = 0.085 kg",
+            weight_in_kg=0.085,
+        ),
+        WeightEstimate(
+            ingredient="3 tsk salt",
+            weight_calculation="1 tsk = 5 g, 3 * 5 g = 15 g = 0.015 kg",
+            weight_in_kg=0.015,
+        ),
+        WeightEstimate(
+            ingredient="2 spsk krydderier",
+            weight_calculation="1 spsk = 15 g, 2 * 15 g = 30 g = 0.030 kg",
+            weight_in_kg=0.03,
+        ),
+        WeightEstimate(
+            ingredient="peber",
+            weight_calculation="Mængden af peber er ikke angivet. LLM-estimat er: 1 portion = 0.005 kg, 1 * 0.005 kg = 0.005 kg",
+            weight_in_kg=0.005,
+        ),
+        WeightEstimate(
+            ingredient="2 store kartofler",
+            weight_calculation="1 stor kartoffel = 300 g, 2 * 300 g = 600 g = 0.6 kg",
+            weight_in_kg=0.6,
+        ),
+        WeightEstimate(
+            ingredient="1 bundt asparges",
+            weight_calculation="1 bundt asparges = 500 g, 1 * 500 g = 500 g = 0.500 kg",
+            weight_in_kg=0.5,
+        ),
+        WeightEstimate(
+            ingredient="1 and, ca. 2 kg",
+            weight_calculation="1 and, ca. 2 kg = 2000 g, 1 * 2000 g = 2000 g = 2.0 kg",
+            weight_in_kg=2.0,
+        ),
+        WeightEstimate(
+            ingredient="serveres med ris",
+            weight_calculation="Mængden af ingrediens ikke angivet, LLM-estimat er: 1 portion = 0.125 kg, 4 portioner * 0.125 kg = 0.5 kg",
+            weight_in_kg=0.5,
+        ),
+    ]
+)
+
+DA_ANSWER_EXAMPLE = DA_ANSWER_EXAMPLE_OBJ.model_dump_json(indent=2)
+
 WEIGHT_CONVERSION_TEMPLATE_EXPLANATION = "<ingredient name> = <weight in grams>, <amount> * <weight in grams> = <total weight in grams> = <total weight in kg>"
 INGREDIENT_NOT_FOUND_TEMPLATE = f"Ingredient not found in general weights. LLM estimate is: {WEIGHT_CONVERSION_TEMPLATE_EXPLANATION}."
 AMOUNT_NOT_SPECIFIED_TEMPLATE = "Amount of <ingredient> not specified. LLM estimate is: <ingredient name> per serving = <weight in kg>, <number of servings> * <weight in kg> = <total weight in kg>."
@@ -159,6 +264,8 @@ AMOUNT_NOT_SPECIFIED_TEMPLATE = "Amount of <ingredient> not specified. LLM estim
 WEIGHT_EST_SYSTEM_PROMPT = """
 Given a list of ingredients in English or Danish, estimate the weights in kilogram for each ingredient.
 Explain your reasoning for the estimation of weights.
+
+Respond in the same language as the ingredients. Danish inputs require Danish output, and English inputs require English output.
 
 The following general weights can be used for estimation:
 {recalculations}
@@ -192,7 +299,14 @@ WEIGHT_EST_EXAMPLE_AI_PROMPT = """{answer_example}"""
 
 def get_weight_est_prompt(language: Languages) -> ChatPromptTemplate:
     """Return weight estimation prompt with examples for the given language."""
-    input_example = EN_INPUT_EXAMPLE if language == Languages.English else DA_INPUT_EXAMPLE
+    if language == Languages.English:
+        input_example = EN_INPUT_EXAMPLE
+        answer_example = ANSWER_EXAMPLE
+        recalculations = EN_WEIGHT_RECALCULATIONS
+    else:
+        input_example = DA_INPUT_EXAMPLE
+        answer_example = DA_ANSWER_EXAMPLE
+        recalculations = DA_WEIGHT_RECALCULATIONS
     return ChatPromptTemplate(
         messages=[
             SystemMessagePromptTemplate.from_template(WEIGHT_EST_SYSTEM_PROMPT),
@@ -204,9 +318,9 @@ def get_weight_est_prompt(language: Languages) -> ChatPromptTemplate:
         ],
         input_variables=["input", "servings"],
         partial_variables={
-            "recalculations": EN_WEIGHT_RECALCULATIONS,
+            "recalculations": recalculations,
             "input_example": input_example,
-            "answer_example": ANSWER_EXAMPLE,
+            "answer_example": answer_example,
             "weight_conversion_template": WEIGHT_CONVERSION_TEMPLATE_EXPLANATION,
             "ingredient_not_found_template": INGREDIENT_NOT_FOUND_TEMPLATE,
             "amount_not_specified_template": AMOUNT_NOT_SPECIFIED_TEMPLATE,

--- a/tests/data/weight_estimates_json/arla_nytarstorsk.json
+++ b/tests/data/weight_estimates_json/arla_nytarstorsk.json
@@ -1,92 +1,92 @@
 {
     "weight_estimates": [
         {
-            "ingredient": "25 g butter",
+            "ingredient": "25 g smør",
             "weight_calculation": "25 g = 25 g = 0.025 kg",
             "weight_in_kg": 0.025
         },
         {
-            "ingredient": "4 beets (about 400 g)",
+            "ingredient": "4 rødbeder (ca. 400 g)",
             "weight_calculation": "400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "1 dl dark balsamic vinegar",
+            "ingredient": "1 dl mørk balsamicoeddike",
             "weight_calculation": "1 dl = 0.1 kg, 1 * 0.1 kg = 0.1 kg",
             "weight_in_kg": 0.1
         },
         {
-            "ingredient": "2 tablespoons sugar",
+            "ingredient": "2 spsk sukker",
             "weight_calculation": "1 tbsp. = 15 g, 2 * 15 g = 30 g = 0.03 kg",
             "weight_in_kg": 0.03
         },
         {
-            "ingredient": "1 teaspoon coarse salt",
+            "ingredient": "1 tsk groft salt",
             "weight_calculation": "1 tsp. = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "600 g of codeloin",
+            "ingredient": "600 g torskeloin",
             "weight_calculation": "600 g = 600 g = 0.6 kg",
             "weight_in_kg": 0.6
         },
         {
-            "ingredient": "25 g butter",
+            "ingredient": "25 g smør",
             "weight_calculation": "25 g = 25 g = 0.025 kg",
             "weight_in_kg": 0.025
         },
         {
-            "ingredient": "0.5 teaspoon coarse salt",
+            "ingredient": "0.5 tsk groft salt",
             "weight_calculation": "1 tsp. = 5 g, 0.5 * 5 g = 2.5 g = 0.0025 kg",
             "weight_in_kg": 0.0025
         },
         {
-            "ingredient": "1.5 tsp wheat flour",
+            "ingredient": "1.5 tsk hvedemel",
             "weight_calculation": "1 tsp. = 5 g, 1.5 * 5 g = 7.5 g = 0.0075 kg",
             "weight_in_kg": 0.0075
         },
         {
-            "ingredient": "2.5 dl water",
+            "ingredient": "2.5 dl vand",
             "weight_calculation": "1 dl = 0.1 kg, 2.5 * 0.1 kg = 0.25 kg",
             "weight_in_kg": 0.25
         },
         {
-            "ingredient": "3 tablespoons whole yellow mustard seeds",
+            "ingredient": "3 spsk hele gule sennepsfrø",
             "weight_calculation": "1 tbsp. = 15 g, 3 * 15 g = 45 g = 0.045 kg",
             "weight_in_kg": 0.045
         },
         {
-            "ingredient": "6 finely chopped shallots (about 75 g)",
+            "ingredient": "6 finthakkede skalotteløg (ca. 75 g)",
             "weight_calculation": "75 g = 75 g = 0.075 kg",
             "weight_in_kg": 0.075
         },
         {
-            "ingredient": "200 g of cold butter",
+            "ingredient": "200 g koldt smør",
             "weight_calculation": "200 g = 200 g = 0.2 kg",
             "weight_in_kg": 0.2
         },
         {
-            "ingredient": "0.75 teaspoon coarse salt",
+            "ingredient": "0.75 tsk groft salt",
             "weight_calculation": "1 tsp. = 5 g, 0.75 * 5 g = 3.75 g = 0.00375 kg",
             "weight_in_kg": 0.00375
         },
         {
-            "ingredient": "freshly ground pepper",
+            "ingredient": "friskkværnet peber",
             "weight_calculation": "Amount of freshly ground pepper not specified. LLM estimate is: freshly ground pepper per serving = 0.005 kg, 4 * 0.005 kg = 0.02 kg.",
             "weight_in_kg": 0.02
         },
         {
-            "ingredient": "fresh herbs",
+            "ingredient": "friske krydderurter",
             "weight_calculation": "Amount of fresh herbs not specified. LLM estimate is: fresh herbs per serving = 0.025 kg, 4 * 0.025 kg = 0.1 kg.",
             "weight_in_kg": 0.1
         },
         {
-            "ingredient": "100 g of fried bacon",
+            "ingredient": "100 g stegte bacontern",
             "weight_calculation": "100 g = 100 g = 0.1 kg",
             "weight_in_kg": 0.1
         },
         {
-            "ingredient": "4 soft-boiled quail egg",
+            "ingredient": "4 blødkogte vagtelæg",
             "weight_calculation": "Ingredient not found in general weights. LLM estimate is: 1 quail egg = 10 g, 4 * 10 g = 40 g = 0.04 kg.",
             "weight_in_kg": 0.04
         }

--- a/tests/data/weight_estimates_json/foodfanatic_tacos.json
+++ b/tests/data/weight_estimates_json/foodfanatic_tacos.json
@@ -1,67 +1,67 @@
 {
     "weight_estimates": [
         {
-            "ingredient": "1 small onion",
+            "ingredient": "1 lille løg",
             "weight_calculation": "1 small onion = 100 g, 1 * 100 g = 100 g = 0.1 kg",
             "weight_in_kg": 0.1
         },
         {
-            "ingredient": "2 cloves of garlic",
+            "ingredient": "2 fed hvidløg",
             "weight_calculation": "1 clove garlic = 4 g, 2 * 4 g = 8 g = 0.008 kg",
             "weight_in_kg": 0.008
         },
         {
-            "ingredient": "0.5 Red pepper",
+            "ingredient": "0.5 rød peberfrugt",
             "weight_calculation": "1 bell pepper = 150 g, 0.5 * 150 g = 75 g = 0.075 kg",
             "weight_in_kg": 0.075
         },
         {
-            "ingredient": "oil",
+            "ingredient": "olie",
             "weight_calculation": "Amount of oil not specified. LLM estimate is: 1 serving = 0.015 kg, 2 * 0.015 kg = 0.03 kg",
             "weight_in_kg": 0.03
         },
         {
-            "ingredient": "250 g of beef",
+            "ingredient": "250 g oksekød",
             "weight_calculation": "250 g = 250 g = 0.25 kg",
             "weight_in_kg": 0.25
         },
         {
-            "ingredient": "1.5 tablespoons fajita crawling",
+            "ingredient": "1.5 spsk fajitakrydderi",
             "weight_calculation": "1 tbsp. = 15 g, 1.5 * 15 g = 22.5 g = 0.0225 kg",
             "weight_in_kg": 0.0225
         },
         {
-            "ingredient": "chili powder or flakes",
+            "ingredient": "chilipulver eller flager",
             "weight_calculation": "Amount of chili powder or flakes not specified. LLM estimate is: 1 serving = 0.005 kg, 2 * 0.005 kg = 0.01 kg",
             "weight_in_kg": 0.01
         },
         {
-            "ingredient": "1 can of kidney beans",
+            "ingredient": "1 dåse kidneybønner",
             "weight_calculation": "1 can = 400 g, 1 * 400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "2 tablespoons tomato puree",
+            "ingredient": "2 spsk tomatpuré",
             "weight_calculation": "1 tbsp. = 15 g, 2 * 15 g = 30 g = 0.03 kg",
             "weight_in_kg": 0.03
         },
         {
-            "ingredient": "2.5 dl beef fund/broth",
+            "ingredient": "2.5 dl oksefond/-bouillon",
             "weight_calculation": "1 dl = 0.1 kg, 2.5 * 0.1 kg = 0.25 kg",
             "weight_in_kg": 0.25
         },
         {
-            "ingredient": "11 small cornstortillas",
+            "ingredient": "11 små majstortillas",
             "weight_calculation": "1 tortilla = 30 g, 11 * 30 g = 330 g = 0.33 kg",
             "weight_in_kg": 0.33
         },
         {
-            "ingredient": "1 serving of tomato salsa",
+            "ingredient": "1 portion tomatsalsa",
             "weight_calculation": "Amount of tomato salsa not specified. LLM estimate is: 1 serving = 0.1 kg, 1 * 0.1 kg = 0.1 kg",
             "weight_in_kg": 0.1
         },
         {
-            "ingredient": "1 Avocado",
+            "ingredient": "1 avocado",
             "weight_calculation": "Ingredient not found in general weights. LLM estimate is: 1 Avocado = 170 g, 1 * 170 g = 170 g = 0.17 kg.",
             "weight_in_kg": 0.17
         },
@@ -71,42 +71,42 @@
             "weight_in_kg": 0.01
         },
         {
-            "ingredient": "pepper",
+            "ingredient": "peber",
             "weight_calculation": "Amount of pepper not specified. LLM estimate is: 1 serving = 0.005 kg, 2 * 0.005 kg = 0.01 kg",
             "weight_in_kg": 0.01
         },
         {
-            "ingredient": "0.5 Red onion",
+            "ingredient": "0.5 rødløg",
             "weight_calculation": "1 onion = 170 g, 0.5 * 170 g = 85 g = 0.085 kg",
             "weight_in_kg": 0.085
         },
         {
-            "ingredient": "2 cloves of garlic",
+            "ingredient": "2 fed hvidløg",
             "weight_calculation": "1 clove garlic = 4 g, 2 * 4 g = 8 g = 0.008 kg",
             "weight_in_kg": 0.008
         },
         {
-            "ingredient": "300 g of tomatoes",
+            "ingredient": "300 g tomater",
             "weight_calculation": "300 g = 300 g = 0.3 kg",
             "weight_in_kg": 0.3
         },
         {
-            "ingredient": "0.75 chili pepper",
+            "ingredient": "0.75 chilipeber",
             "weight_calculation": "Ingredient not found in general weights. LLM estimate is: 1 chili pepper = 50 g, 0.75 * 50 g = 37.5 g = 0.0375 kg.",
             "weight_in_kg": 0.0375
         },
         {
-            "ingredient": "0.5 Bdt coriander",
+            "ingredient": "0.5 bdt koriander",
             "weight_calculation": "1 bunch parsley = 50 g, 0.5 * 50 g = 25 g = 0.025 kg",
             "weight_in_kg": 0.025
         },
         {
-            "ingredient": "2 tablespoons olive oil",
+            "ingredient": "2 spsk olivenolie",
             "weight_calculation": "1 tbsp. = 15 g, 2 * 15 g = 30 g = 0.03 kg",
             "weight_in_kg": 0.03
         },
         {
-            "ingredient": "The juice of 0.5 lime",
+            "ingredient": "saften af 0.5 lime",
             "weight_calculation": "1 lime = 60 g, 0.5 * 60 g = 30 g = 0.03 kg",
             "weight_in_kg": 0.03
         },
@@ -116,7 +116,7 @@
             "weight_in_kg": 0.01
         },
         {
-            "ingredient": "Pepper",
+            "ingredient": "peber",
             "weight_calculation": "Amount of Pepper not specified. LLM estimate is: 1 serving = 0.005 kg, 2 * 0.005 kg = 0.01 kg",
             "weight_in_kg": 0.01
         }

--- a/tests/data/weight_estimates_json/gourministeriet_bolognese.json
+++ b/tests/data/weight_estimates_json/gourministeriet_bolognese.json
@@ -1,67 +1,67 @@
 {
     "weight_estimates": [
         {
-            "ingredient": "1 kg of minced beef",
+            "ingredient": "1 kg hakket oksekød",
             "weight_calculation": "1 kg = 1000 g = 1.0 kg",
             "weight_in_kg": 1.0
         },
         {
-            "ingredient": "3 large onions",
+            "ingredient": "3 store løg",
             "weight_calculation": "1 onion = 170 g, 3 * 170 g = 510 g = 0.51 kg",
             "weight_in_kg": 0.51
         },
         {
-            "ingredient": "3 carrots",
+            "ingredient": "3 gulerødder",
             "weight_calculation": "1 carrot = 100 g, 3 * 100 g = 300 g = 0.3 kg",
             "weight_in_kg": 0.3
         },
         {
-            "ingredient": "2.5 Stalk leaf celery",
+            "ingredient": "2.5 stilke bladselleri",
             "weight_calculation": "Ingredient not found in general weights. LLM estimate is: 1 stalk leaf celery = 40 g, 2.5 * 40 g = 100 g = 0.1 kg.",
             "weight_in_kg": 0.1
         },
         {
-            "ingredient": "6 cloves of garlic",
+            "ingredient": "6 fed hvidløg",
             "weight_calculation": "1 clove garlic = 4 g, 6 * 4 g = 24 g = 0.024 kg",
             "weight_in_kg": 0.024
         },
         {
-            "ingredient": "150 g tomato concentrate",
+            "ingredient": "150 g tomatkoncentrat",
             "weight_calculation": "150 g = 150 g = 0.15 kg",
             "weight_in_kg": 0.15
         },
         {
-            "ingredient": "3 can of chopped tomatoes or polpa",
+            "ingredient": "3 dåse hakkede tomater eller polpa",
             "weight_calculation": "1 can = 400 g, 3 * 400 g = 1200 g = 1.2 kg",
             "weight_in_kg": 1.2
         },
         {
-            "ingredient": "2 dl red wine",
+            "ingredient": "2 dl rødvin",
             "weight_calculation": "1 dl = 100 g, 2 * 100 g = 200 g = 0.2 kg",
             "weight_in_kg": 0.2
         },
         {
-            "ingredient": "0.5 tsp rosemary",
+            "ingredient": "0.5 tsk rosmarin",
             "weight_calculation": "1 tsp = 5 g, 0.5 * 5 g = 2.5 g = 0.0025 kg",
             "weight_in_kg": 0.0025
         },
         {
-            "ingredient": "0.5 tsp thyme",
+            "ingredient": "0.5 tsk timian",
             "weight_calculation": "1 tsp = 5 g, 0.5 * 5 g = 2.5 g = 0.0025 kg",
             "weight_in_kg": 0.0025
         },
         {
-            "ingredient": "1 tsp oregano",
+            "ingredient": "1 tsk oregano",
             "weight_calculation": "1 tsp = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "1 tsp basil",
+            "ingredient": "1 tsk basilikum",
             "weight_calculation": "1 tsp = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "Oil",
+            "ingredient": "Olie",
             "weight_calculation": "Amount of Oil not specified. LLM estimate is: Oil per serving = 0.015 kg, 8 * 0.015 kg = 0.12 kg.",
             "weight_in_kg": 0.12
         },
@@ -71,22 +71,22 @@
             "weight_in_kg": 0.04
         },
         {
-            "ingredient": "freshly ground pepper",
+            "ingredient": "friskekværnet peber",
             "weight_calculation": "Amount of freshly ground pepper not specified. LLM estimate is: freshly ground pepper per serving = 0.005 kg, 8 * 0.005 kg = 0.04 kg.",
             "weight_in_kg": 0.04
         },
         {
-            "ingredient": "1 handful of fresh basil leaves",
+            "ingredient": "1 håndfuld friske basilikumblade",
             "weight_calculation": "1 handful of herbs = 25 g, 1 * 25 g = 25 g = 0.025 kg",
             "weight_in_kg": 0.025
         },
         {
-            "ingredient": "Pasta as desired",
+            "ingredient": "Pasta efter ønske",
             "weight_calculation": "Amount of Pasta as desired not specified. LLM estimate is: Pasta as desired per serving = 0.125 kg, 8 * 0.125 kg = 1.0 kg.",
             "weight_in_kg": 1.0
         },
         {
-            "ingredient": "Torn parmesan",
+            "ingredient": "Revet parmesan",
             "weight_calculation": "Amount of Torn parmesan not specified. LLM estimate is: Torn parmesan per serving = 0.02 kg, 8 * 0.02 kg = 0.16 kg.",
             "weight_in_kg": 0.16
         }

--- a/tests/data/weight_estimates_json/madogkaerlighed_pasta_asparges.json
+++ b/tests/data/weight_estimates_json/madogkaerlighed_pasta_asparges.json
@@ -1,72 +1,72 @@
 {
     "weight_estimates": [
         {
-            "ingredient": "250 g fresh pasta",
+            "ingredient": "250 g frisk pasta",
             "weight_calculation": "250 g = 250 g = 0.25 kg",
             "weight_in_kg": 0.25
         },
         {
-            "ingredient": "2 cloves of garlic",
+            "ingredient": "2 fed hvidløg",
             "weight_calculation": "1 clove garlic = 4 g, 2 * 4 g = 8 g = 0.008 kg",
             "weight_in_kg": 0.008
         },
         {
-            "ingredient": "1 onion",
+            "ingredient": "1 løg",
             "weight_calculation": "1 onion = 170 g, 1 * 170 g = 170 g = 0.17 kg",
             "weight_in_kg": 0.17
         },
         {
-            "ingredient": "1 BDT Green Asparagus",
+            "ingredient": "1 bdt grønne asparges",
             "weight_calculation": "Ingredient not found in general weights. LLM estimate is: 1 BDT Green Asparagus = 500 g, 1 * 500 g = 500 g = 0.5 kg.",
             "weight_in_kg": 0.5
         },
         {
-            "ingredient": "1 Squash",
+            "ingredient": "1 squash",
             "weight_calculation": "1 squash = 400 g, 1 * 400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "1 large handful of basil",
+            "ingredient": "1 stor håndfuld basilikum",
             "weight_calculation": "1 handful of herbs = 25 g, 1 * 25 g = 25 g = 0.025 kg",
             "weight_in_kg": 0.025
         },
         {
-            "ingredient": "2 dl cream",
+            "ingredient": "2 dl fløde",
             "weight_calculation": "1 dl = 100 g, 2 * 100 g = 200 g = 0.2 kg",
             "weight_in_kg": 0.2
         },
         {
-            "ingredient": "1 dl water",
+            "ingredient": "1 dl vand",
             "weight_calculation": "1 dl = 100 g, 1 * 100 g = 100 g = 0.1 kg",
             "weight_in_kg": 0.1
         },
         {
-            "ingredient": "1 vegetable broth cube",
+            "ingredient": "1 grøntsags bouillonterning",
             "weight_calculation": "1 bouillon cube = 4 g, 1 * 4 g = 4 g = 0.004 kg",
             "weight_in_kg": 0.004
         },
         {
-            "ingredient": "6 tbsp grated parmesan",
+            "ingredient": "6 spsk revet parmesan",
             "weight_calculation": "1 tbsp. = 15 g, 6 * 15 g = 90 g = 0.09 kg",
             "weight_in_kg": 0.09
         },
         {
-            "ingredient": "1 handful of mozzarella",
+            "ingredient": "1 håndfuld mozzarella",
             "weight_calculation": "Ingredient not found in general weights. LLM estimate is: 1 handful of mozzarella = 100 g, 1 * 100 g = 100 g = 0.1 kg.",
             "weight_in_kg": 0.1
         },
         {
-            "ingredient": "A little salt",
+            "ingredient": "Lidt salt",
             "weight_calculation": "Amount of A little salt not specified. LLM estimate is: A little salt per serving = 0.005 kg, 2 * 0.005 kg = 0.01 kg.",
             "weight_in_kg": 0.01
         },
         {
-            "ingredient": "A little pepper",
+            "ingredient": "Lidt peber",
             "weight_calculation": "Amount of A little pepper not specified. LLM estimate is: A little pepper per serving = 0.005 kg, 2 * 0.005 kg = 0.01 kg.",
             "weight_in_kg": 0.01
         },
         {
-            "ingredient": "Oil",
+            "ingredient": "Olie",
             "weight_calculation": "Amount of Oil not specified. LLM estimate is: Oil per serving = 0.015 kg, 2 * 0.015 kg = 0.03 kg.",
             "weight_in_kg": 0.03
         }

--- a/tests/data/weight_estimates_json/valdemarsro_tomatrisotto.json
+++ b/tests/data/weight_estimates_json/valdemarsro_tomatrisotto.json
@@ -1,47 +1,47 @@
 {
     "weight_estimates": [
         {
-            "ingredient": "1 onion",
+            "ingredient": "1 stk løg",
             "weight_calculation": "1 onion = 170 g, 1 * 170 g = 170 g = 0.17 kg",
             "weight_in_kg": 0.17
         },
         {
-            "ingredient": "3 cloves of garlic",
+            "ingredient": "3 fed hvidløg",
             "weight_calculation": "1 clove garlic = 4 g, 3 * 4 g = 12 g = 0.012 kg",
             "weight_in_kg": 0.012
         },
         {
-            "ingredient": "400 g risotto rice",
+            "ingredient": "400 g risotto ris",
             "weight_calculation": "400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "2 dl white wine",
+            "ingredient": "2 dl hvidvin",
             "weight_calculation": "1 dl = 100 g, 2 * 100 g = 200 g = 0.2 kg",
             "weight_in_kg": 0.2
         },
         {
-            "ingredient": "400 g of ripped tomatoes",
+            "ingredient": "400 g flåede tomater",
             "weight_calculation": "400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "25 g tomato puree",
+            "ingredient": "25 g tomatpuré",
             "weight_calculation": "25 g = 25 g = 0.025 kg",
             "weight_in_kg": 0.025
         },
         {
-            "ingredient": "9 dl vegetable broth",
+            "ingredient": "9 dl grøntsagsbouillon",
             "weight_calculation": "1 dl = 100 g, 9 * 100 g = 900 g = 0.9 kg",
             "weight_in_kg": 0.9
         },
         {
-            "ingredient": "0.5 tsp thyme",
+            "ingredient": "0.5 tsk timian",
             "weight_calculation": "1 tsp. = 5 g, 0.5 * 5 g = 2.5 g = 0.0025 kg",
             "weight_in_kg": 0.0025
         },
         {
-            "ingredient": "25 g sun -dried tomatoes in oil",
+            "ingredient": "25 g soltørrede tomater i olie",
             "weight_calculation": "25 g = 25 g = 0.025 kg",
             "weight_in_kg": 0.025
         },
@@ -51,12 +51,12 @@
             "weight_in_kg": 0.125
         },
         {
-            "ingredient": "0.5 ECO Lemon",
+            "ingredient": "0.5 øko citron",
             "weight_calculation": "1 lemon = 85 g, 0.5 * 85 g = 42.5 g = 0.0425 kg",
             "weight_in_kg": 0.0425
         },
         {
-            "ingredient": "1 tablespoon olive oil",
+            "ingredient": "1 spsk olivenolie",
             "weight_calculation": "1 tbsp. = 15 g, 1 * 15 g = 15 g = 0.015 kg",
             "weight_in_kg": 0.015
         },
@@ -66,7 +66,7 @@
             "weight_in_kg": 0.02
         },
         {
-            "ingredient": "Black pepper",
+            "ingredient": "sort peber",
             "weight_calculation": "Amount of Black pepper not specified. LLM estimate is: Black pepper per serving = 0.005 kg, 4 * 0.005 kg = 0.02 kg.",
             "weight_in_kg": 0.02
         },
@@ -86,7 +86,7 @@
             "weight_in_kg": 0.025
         },
         {
-            "ingredient": "0.5 Handful of basil",
+            "ingredient": "0.5 håndfuld basilikum",
             "weight_calculation": "1 Handful of herbs (basil, oregano etc.) = 25 g, 0.5 * 25 g = 12.5 g = 0.0125 kg",
             "weight_in_kg": 0.0125
         }

--- a/tests/data/weight_estimates_json/valdemarsro_vegetar_enchiladas.json
+++ b/tests/data/weight_estimates_json/valdemarsro_vegetar_enchiladas.json
@@ -1,57 +1,57 @@
 {
     "weight_estimates": [
         {
-            "ingredient": "1 tsp steady cumin",
+            "ingredient": "1 tsk stødt spidskommen",
             "weight_calculation": "1 tsp. = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "1 teaspoon of cinnamon",
+            "ingredient": "1 tsk stødt kanel",
             "weight_calculation": "1 tsp. = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "1 teaspoon smoked paprika",
+            "ingredient": "1 tsk røget paprika",
             "weight_calculation": "1 tsp. = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "1 tsp steady coriander",
+            "ingredient": "1 tsk stødt koriander",
             "weight_calculation": "1 tsp. = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "2 cloves of garlic",
+            "ingredient": "2 fed hvidløg",
             "weight_calculation": "1 clove garlic = 4 g, 2 * 4 g = 8 g = 0.008 kg",
             "weight_in_kg": 0.008
         },
         {
-            "ingredient": "1 tablespoon olive oil",
+            "ingredient": "1 spsk olivenolie",
             "weight_calculation": "1 tbsp. = 15 g, 1 * 15 g = 15 g = 0.015 kg",
             "weight_in_kg": 0.015
         },
         {
-            "ingredient": "1 onion",
+            "ingredient": "1 løg",
             "weight_calculation": "1 onion = 170 g, 1 * 170 g = 170 g = 0.170 kg",
             "weight_in_kg": 0.17
         },
         {
-            "ingredient": "1 tsp wheat flour",
+            "ingredient": "1 tsk hvedemel",
             "weight_calculation": "1 tsp. = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "1 dl vegetable broth",
+            "ingredient": "1 dl grøntsagsbouillon",
             "weight_calculation": "1 dl = 100 g, 1 * 100 g = 100 g = 0.1 kg",
             "weight_in_kg": 0.1
         },
         {
-            "ingredient": "1 can of chopped tomatoes",
+            "ingredient": "1 dåse hakkede tomater",
             "weight_calculation": "1 can = 400 g, 1 * 400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "1 tablespoon olive oil",
+            "ingredient": "1 spsk olivenolie",
             "weight_calculation": "1 tbsp. = 15 g, 1 * 15 g = 15 g = 0.015 kg",
             "weight_in_kg": 0.015
         },
@@ -61,67 +61,67 @@
             "weight_in_kg": 0.02
         },
         {
-            "ingredient": "Black pepper",
+            "ingredient": "sort peber",
             "weight_calculation": "Amount of Black pepper not specified. LLM estimate is: 1 serving = 0.005 kg, 4 * 0.005 kg = 0.02 kg",
             "weight_in_kg": 0.02
         },
         {
-            "ingredient": "1 onion",
+            "ingredient": "1 løg",
             "weight_calculation": "1 onion = 170 g, 1 * 170 g = 170 g = 0.170 kg",
             "weight_in_kg": 0.17
         },
         {
-            "ingredient": "2 cloves of garlic",
+            "ingredient": "2 fed hvidløg",
             "weight_calculation": "1 clove garlic = 4 g, 2 * 4 g = 8 g = 0.008 kg",
             "weight_in_kg": 0.008
         },
         {
-            "ingredient": "1 Squash",
+            "ingredient": "1 squash",
             "weight_calculation": "1 squash = 400 g, 1 * 400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "1 can of chopped tomatoes",
+            "ingredient": "1 dåse hakkede tomater",
             "weight_calculation": "1 can = 400 g, 1 * 400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "1 tsp steady cumin",
+            "ingredient": "1 tsk stødt spidskommen",
             "weight_calculation": "1 tsp. = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "1 tsp steady coriander",
+            "ingredient": "1 tsk stødt koriander",
             "weight_calculation": "1 tsp. = 5 g, 1 * 5 g = 5 g = 0.005 kg",
             "weight_in_kg": 0.005
         },
         {
-            "ingredient": "1 can of black beans",
+            "ingredient": "1 dåse sorte bønner",
             "weight_calculation": "1 can = 400 g, 1 * 400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "1 can of kidney beans",
+            "ingredient": "1 dåse kidneybønner",
             "weight_calculation": "1 can = 400 g, 1 * 400 g = 400 g = 0.4 kg",
             "weight_in_kg": 0.4
         },
         {
-            "ingredient": "300 g of corn",
+            "ingredient": "300 g majs",
             "weight_calculation": "300 g = 300 g = 0.3 kg",
             "weight_in_kg": 0.3
         },
         {
-            "ingredient": "8 Tortilla's pancakes",
+            "ingredient": "8 tortillas pandekager",
             "weight_calculation": "1 tortilla = 30 g, 8 * 30 g = 240 g = 0.24 kg",
             "weight_in_kg": 0.24
         },
         {
-            "ingredient": "150 g cheddar cheese",
+            "ingredient": "150 g cheddar ost",
             "weight_calculation": "150 g = 150 g = 0.15 kg",
             "weight_in_kg": 0.15
         },
         {
-            "ingredient": "1 handful of fresh coriander",
+            "ingredient": "1 håndfuld frisk koriander",
             "weight_calculation": "Handful of herbs = 25 g, 1 * 25 g = 25 g = 0.025 kg",
             "weight_in_kg": 0.025
         },
@@ -131,12 +131,12 @@
             "weight_in_kg": 0.02
         },
         {
-            "ingredient": "Black pepper",
+            "ingredient": "sort peber",
             "weight_calculation": "Amount of Black pepper not specified. LLM estimate is: 1 serving = 0.005 kg, 4 * 0.005 kg = 0.02 kg",
             "weight_in_kg": 0.02
         },
         {
-            "ingredient": "1 tablespoon butter",
+            "ingredient": "1 spsk smør",
             "weight_calculation": "1 tbsp. = 15 g, 1 * 15 g = 15 g = 0.015 kg",
             "weight_in_kg": 0.015
         }


### PR DESCRIPTION
## Summary
- translate weight estimator lookup table and answer example to Danish
- select examples and lookup table per language
- clarify language instructions in recipe extractor and weight estimator prompts
- update expected weight estimate test data to Danish ingredient names

## Testing
- `pip install -q pytest-xdist`
- `pip install -q protobuf==3.20.*`
- `pytest -q` *(fails: fixture 'mocker' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff791d00832da8cb948d586c50ba