### PR TITLE
Add agent documentation

### DIFF
--- a/agents/CHANGELOG.md
+++ b/agents/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2024-06-05
+- Added the `agents/` documentation directory.
+- Created detailed README files for `app`, `food_co2_estimator`, and `foodprint`.
+- Added `LEARNINGS.md` for accumulated insights about the code base.

--- a/agents/LEARNINGS.md
+++ b/agents/LEARNINGS.md
@@ -1,0 +1,10 @@
+# Learnings
+
+This file collects observations about how the repository is organised and coding preferences that emerge over time.
+
+- **Coding style** – Python code is formatted with [Ruff](https://github.com/astral-sh/ruff) and checked with `pyright`.  The `pyproject.toml` sets a line length of 88 characters.
+- **Asynchronous design** – Many functions, especially in the estimator, are asynchronous.  Tests use `pytest` with `pytest-asyncio`.
+- **Environment variables** – Configuration such as API keys, cache options and model vendor are read from the environment.  The provided `template.env` shows required keys.
+- **Caching strategy** – Results can be cached in Google Cloud Storage and re-used by providing the `USE_CACHE` and `STORE_IN_CACHE` flags.
+
+Further insights should be appended here as the code evolves.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,13 @@
+# Agent Documentation Overview
+
+This folder contains documentation aimed at LLM-based agents.  It explains how the repository is structured and how the major pieces of the application work together.
+
+The repository provides a FastAPI backend together with a SvelteKit frontend.  The backend exposes an API for estimating the CO₂ footprint of recipes and relies on the `food_co2_estimator` library.  The frontend lives in `foodprint/` and interacts with these endpoints.
+
+The following sub‑folders contain detailed explanations for each part of the code base:
+
+- **food_co2_estimator/** – Library implementing the estimation logic
+- **app/** – FastAPI application and supporting files
+- **foodprint/** – SvelteKit user interface
+
+Additional files include a `CHANGELOG.md` describing repository updates and a `LEARNINGS.md` file where insights about the code base and coding style are collected.

--- a/agents/app/README.md
+++ b/agents/app/README.md
@@ -1,0 +1,23 @@
+# Backend Application (`app`)
+
+This folder documents the FastAPI service defined in `app.py` along with its auxiliary files.
+
+## Responsibilities
+- Expose HTTP endpoints used by the frontend.
+- Start and manage a Redis connection for job status and rate limiting.
+- Launch background tasks that run the CO₂ estimation workflow from `food_co2_estimator`.
+
+## Main File
+### `app.py`
+- Creates the FastAPI instance with CORS support.
+- Provides `/estimate`, `/status/{uid}`, `/comparison` and optional rate limiting.
+- Uses `RedisCache` to track job progress and to enforce request limits.
+- The `run_estimator` task invokes `food_co2_estimator.main.async_estimator` and stores the result back in Redis.
+
+## Supporting Files
+- `start.sh` – Entry script used by Docker images.  It starts a local Redis server and runs `uvicorn`.
+- `logging_config.yaml` – Configures log levels for the application and `uvicorn` server.
+- `Dockerfile` and `cloudbuild.yaml` – Build and deployment configuration for running in containers or on Google Cloud Run.
+- `template.env` – Example environment variables required for authentication and configuration.
+
+These endpoints power the frontend in `foodprint/` and use the estimation logic described in the `food_co2_estimator` documentation.

--- a/agents/food_co2_estimator/README.md
+++ b/agents/food_co2_estimator/README.md
@@ -1,0 +1,29 @@
+# Library: `food_co2_estimator`
+
+This package contains all logic for estimating the CO₂ footprint of a recipe.  It is used both by the FastAPI backend and by tests.
+
+## Overview
+1. **`main.py`** – Entry point for the estimation pipeline.  The `async_estimator` function orchestrates:
+   - Converting recipe webpages to Markdown (`url/url2markdown.py`).
+   - Extracting structured recipe data with an LLM (`chains/recipe_extractor.py`).
+   - Estimating ingredient weights (`chains/weight_estimator.py`).
+   - Looking up CO₂ emissions via a retrieval‑augmented chain (`chains/rag_co2_estimator.py`).
+   - Generating final output models (`utils/output_generator.py`).
+   The pipeline updates Redis with progress states defined in `pydantic_models.response_models`.
+
+2. **`blob_caching.py`** – Optional caching layer storing estimation results in Google Cloud Storage.  Decorators allow results to be reused across runs.
+
+3. **`rediscache.py`** – Async wrapper around Redis used for job status, caching and rate limiting.
+
+4. **`co2_comparison.py`** – Utility to compare a CO₂ value against a reference trip, returned via a Pydantic model.
+
+## Sub‑packages
+- **`chains/`** – LangChain runnable chains for recipe extraction, weight estimation and emission retrieval.
+- **`retrievers/`** – Helpers for vector database retrieval (`vector_db_retriever.py`) and web search retrieval (`search_retriever.py`).
+- **`language/`** – Language detection using `langdetect`.
+- **`pydantic_models/`** – Typed models describing recipes, emissions and API responses.
+- **`utils/`** – Abstractions for choosing the LLM vendor (`llm_model.py`) and building the final response (`output_generator.py`).
+- **`url/`** – Functions for parsing webpages and removing unwanted HTML prior to LLM processing.
+- **`data/`** – Contains the vector store, SQLite DB and constants used by the retrievers.
+
+The modules in this package are designed to be composable and mostly async so that the FastAPI app can run intensive tasks in the background without blocking.

--- a/agents/foodprint/README.md
+++ b/agents/foodprint/README.md
@@ -1,0 +1,12 @@
+# Frontend (`foodprint`)
+
+The `foodprint` directory contains the SvelteKit based user interface.  It communicates with the FastAPI backend via `/api/*` endpoints exposed from the SvelteKit server side.
+
+## Structure
+- `src/routes` – API routes and pages.  For example `api/estimate/+server.ts` proxies a POST request to the backend `/estimate` endpoint.
+- `src/lib` – Reusable components and TypeScript types used across the application.  Notable components include `IngredientCard.svelte` and `EmissionBarChart.svelte`.
+- `static` – Static assets such as icons.
+- `svelte.config.js` and `vite.config.ts` – Build configuration.
+- `package.json` – Declares npm scripts and dependencies.  Tailwind CSS and Flowbite provide the UI styling.
+
+The frontend expects the environment variables `API_BASE` and `FOODPRINT_API_KEY` to be supplied when running locally or in Docker.  It forwards user input to the backend and displays the resulting emission estimates and progress information.


### PR DESCRIPTION
## Summary
- document repository layout for LLM agents
- add README files describing the `app`, `food_co2_estimator` and `foodprint` directories
- record first changelog entry and style learnings

## Testing
- `poetry install --with test --no-interaction`
- `make test` *(fails: google auth credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a4c5ea010832dbc9218916a97a070